### PR TITLE
Remove win10 platform based on Cordova

### DIFF
--- a/platforms.json
+++ b/platforms.json
@@ -15,10 +15,6 @@
         "packageName": "pwabuilder-cordova",
         "source": "pwabuilder-cordova"
     },
-    "windows": {
-        "packageName": "pwabuilder-cordova",
-        "source": "pwabuilder-cordova"
-    },
     "web": {
         "packageName": "pwabuilder-web",
         "source": "pwabuilder-web"


### PR DESCRIPTION
Removed windows platform based on Cordova from default platforms stated on platforms.json. This platform caused an error after trying to build the PWA for iOS.